### PR TITLE
feat: make toolchain bootstrap configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,25 +5,35 @@ Built on top of releases from https://github.com/WebAssembly/wasi-sdk
 
 ## Getting started
 
-### Method 1: Using FetchContent to load the toolchain from Github
-
 Add the following cmake file somewhere in your project. For this example, it is named `wasi-sdk.toolchain.cmake` in a `cmake/wasi-sdk` directory.
 
 ```cmake
 include(FetchContent)
 
+# Fetch the WASI toolchain from Github
 set(FETCHCONTENT_FULLY_DISCONNECTED_OLD ${FETCHCONTENT_FULLY_DISCONNECTED})
 set(FETCHCONTENT_FULLY_DISCONNECTED OFF)
 FetchContent_Declare(
   wasi_sdk_toolchain
   SOURCE_DIR "${CMAKE_BINARY_DIR}/_deps/wasi-sdk"
   GIT_REPOSITORY https://github.com/rioam2/wasi-sdk-toolchain.git
-  GIT_TAG wasi-sdk-23
+  GIT_TAG scratch/make-init-generic
 )
 FetchContent_MakeAvailable(wasi_sdk_toolchain)
 set(FETCHCONTENT_FULLY_DISCONNECTED ${FETCHCONTENT_FULLY_DISCONNECTED_OLD})
 
+# Source toolchain file(s)
 include("${wasi_sdk_toolchain_SOURCE_DIR}/wasi-sdk.toolchain.cmake")
+
+# Initialize a specific version of the WASI toolchain
+# These are example versions, set them as needed for your project
+initialize_wasi_toolchain(
+  WIT_BINDGEN_TAG "v0.29.0"
+  WASMTIME_TAG "v23.0.1"
+  WASM_TOOLS_TAG "v1.215.0"
+  WASI_SDK_TAG "wasi-sdk-23"
+  TARGET_TRIPLET "wasm32-wasip1-threads"
+)
 ```
 
 `FETCHCONTENT_FULLY_DISCONNECTED` is forced to off to ensure that the toolchain is always fetched and loaded, regardless of your project's configuration. It is set back to it's original value after the toolchain is loaded.
@@ -33,11 +43,6 @@ The tag in this example is set to `wasi-sdk-23`. This is configurable and can be
 Finally, set this CMake cache variable:
 
 `cmake ... -DCMAKE_TOOLCHAIN_FILE=path/to/wasi-sdk.toolchain.cmake`
-
-
-### Method 2: Cloning the toolchain directly
-
-Clone this repo directly into a directory of your choosing, then set `CMAKE_TOOLCHAIN_FILE` to point to `wasi-sdk.toolchain.cmake`.
 
 ## Using wit-bindgen to create a component
 
@@ -53,6 +58,13 @@ wit_bindgen(
 # ...
 
 add_executable(<target> ${wit_codegen_output_files} ...)
+
+# Create a WebAssembly Component
+wasm_create_component(
+    COMPONENT_TARGET <name_of_wasm_component_target>
+    CORE_WASM_TARGET <target>
+    COMPONENT_TYPE "reactor"
+)
 ```
 
 This generates WIT bindings for the `.wit` file provided by `INTERFACE_FILE_INPUT`. The resulting bindings will be placed in the `BINDINGS_DIR_INPUT` directory. Additionally, a list of the generated files will be placed in a list variable given by `GENERATED_FILES_OUTPUT`. This list can be provided to a later call to `add_executable` as sources/headers to link with your executable.

--- a/wasi-sdk.toolchain.cmake
+++ b/wasi-sdk.toolchain.cmake
@@ -1,6 +1,9 @@
 include_guard(GLOBAL)
 cmake_minimum_required(VERSION 3.25)
 
+# Keep track of whether the toolchain has been initialized
+set(WASI_TOOLCHAIN_INITIALIZED OFF)
+
 # Function to initialize the toolchain given specific versions of the supporting tools
 function(initialize_wasi_toolchain)
     # Parse arguments to the function
@@ -17,9 +20,9 @@ function(initialize_wasi_toolchain)
         )
     endif()
 
-    # Guard against being called from within a try_compile
+    # Guard against being called from within a try_compile or if the toolchain has already been initialized
     get_property(IN_TRY_COMPILE GLOBAL PROPERTY IN_TRY_COMPILE)
-    if (IN_TRY_COMPILE)
+    if (IN_TRY_COMPILE OR WASI_TOOLCHAIN_INITIALIZED)
       return()
     endif()
     unset(IN_TRY_COMPILE)
@@ -118,5 +121,8 @@ function(initialize_wasi_toolchain)
     
     add_library(wasi_sdk_stub_libc_unimplmented INTERFACE)
     target_compile_options(wasi_sdk_stub_libc_unimplmented INTERFACE -include "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/include/wasi_stub_libc_unimplmented")
+
+    # Set the toolchain as initialized
+    set(WASI_TOOLCHAIN_INITIALIZED ON PARENT_SCOPE)
 
 endfunction()

--- a/wasi-sdk.toolchain.cmake
+++ b/wasi-sdk.toolchain.cmake
@@ -39,6 +39,7 @@ function(initialize_wasi_toolchain)
       WIT_BINDGEN_TAG "${arg_WIT_BINDGEN_TAG}"
       WIT_BINDGEN_BINARY_OUTPUT "_wit_bindgen_binary"
     )
+    set(_wit_bindgen_binary "${_wit_bindgen_binary}" PARENT_SCOPE)
     
     # Add wasm-tools utilities
     include(${CMAKE_CURRENT_FUNCTION_LIST_DIR}/wasm-tools.bootstrap.cmake)
@@ -48,6 +49,8 @@ function(initialize_wasi_toolchain)
       WASM_TOOLS_TAG "${arg_WASM_TOOLS_TAG}"
       WASM_TOOLS_BINARY_OUTPUT "_wasm_tools_binary"
     )
+    set(_wasm_tools_binary "${_wasm_tools_binary}" PARENT_SCOPE)
+    set(_wasm_tools_polyfill_dir "${_wasm_tools_polyfill_dir}" PARENT_SCOPE)
     
     include(${CMAKE_CURRENT_FUNCTION_LIST_DIR}/wasi-sdk.bootstrap.cmake)
     wasi_sdk_bootstrap(

--- a/wasi-sdk.toolchain.cmake
+++ b/wasi-sdk.toolchain.cmake
@@ -10,93 +10,115 @@ endif()
 
 unset(IN_TRY_COMPILE)
 
-# Until Platform/WASI.cmake is upstream we need to inject the path to it
-# into CMAKE_MODULE_PATH.
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+# Function to initialize the toolchain given specific versions of the supporting tools
+function(initialize_wasi_toolchain)
+    # Parse arguments to the function
+    cmake_parse_arguments(
+        PARSE_ARGV 0 "arg"
+        ""
+        "WIT_BINDGEN_TAG;WASMTIME_TAG;WASM_TOOLS_TAG;WASI_SDK_TAG;TARGET_TRIPLET"
+        ""
+    )
+    if (DEFINED arg_UNPARSED_ARGUMENTS)
+        message(FATAL_ERROR
+        "internal error: ${CMAKE_CURRENT_FUNCTION} passed extra args:"
+        "${arg_UNPARSED_ARGUMENTS}"
+        )
+    endif()
 
-# Add wit-bindgen utilities
-include(${CMAKE_CURRENT_LIST_DIR}/wit-bindgen.bootstrap.cmake)
-wit_bindgen_bootstrap(
-  WIT_BINDGEN_TAG "v0.29.0"
-  WIT_BINDGEN_BINARY_OUTPUT "_wit_bindgen_binary"
-)
+    # Until Platform/WASI.cmake is upstream we need to inject the path to it
+    # into CMAKE_MODULE_PATH.
+    list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+    set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" PARENT_SCOPE)
+    
+    # Add wit-bindgen utilities
+    include(${CMAKE_CURRENT_LIST_DIR}/wit-bindgen.bootstrap.cmake)
+    wit_bindgen_bootstrap(
+      WIT_BINDGEN_TAG "${arg_WIT_BINDGEN_TAG}"
+      WIT_BINDGEN_BINARY_OUTPUT "_wit_bindgen_binary"
+    )
+    
+    # Add wasm-tools utilities
+    include(${CMAKE_CURRENT_LIST_DIR}/wasm-tools.bootstrap.cmake)
+    wasm_tools_bootstrap(
+      WASMTIME_POLYFILL_TAG "${arg_WASMTIME_TAG}"
+      WASMTIME_POLYFILL_DIR_OUTPUT "_wasm_tools_polyfill_dir"
+      WASM_TOOLS_TAG "${arg_WASM_TOOLS_TAG}"
+      WASM_TOOLS_BINARY_OUTPUT "_wasm_tools_binary"
+    )
+    
+    include(${CMAKE_CURRENT_LIST_DIR}/wasi-sdk.bootstrap.cmake)
+    wasi_sdk_bootstrap(
+      TAG wasi-sdk-23
+      WASI_SYSROOT_OUTPUT CMAKE_SYSROOT
+      WASI_SDK_BIN_OUTPUT WASI_SDK_BIN
+    )
 
-# Add wasm-tools utilities
-include(${CMAKE_CURRENT_LIST_DIR}/wasm-tools.bootstrap.cmake)
-wasm_tools_bootstrap(
-  WASMTIME_POLYFILL_TAG "v23.0.1"
-  WASMTIME_POLYFILL_DIR_OUTPUT "_wasm_tools_polyfill_dir"
-  WASM_TOOLS_TAG "v1.215.0"
-  WASM_TOOLS_BINARY_OUTPUT "_wasm_tools_binary"
-)
+    set(CMAKE_SYSROOT "${CMAKE_SYSROOT}" PARENT_SCOPE)
+    
+    set(CMAKE_SYSTEM_NAME WASI PARENT_SCOPE)
+    set(CMAKE_SYSTEM_VERSION 1 PARENT_SCOPE)
+    set(CMAKE_SYSTEM_PROCESSOR wasm32 PARENT_SCOPE)
+    set(triple "${arg_TARGET_TRIPLET}")
+    
+    set(CMAKE_C_COMPILER "${WASI_SDK_BIN}/clang" PARENT_SCOPE)
+    set(CMAKE_CXX_COMPILER "${WASI_SDK_BIN}/clang++" PARENT_SCOPE)
+    set(CMAKE_ASM_COMPILER "${WASI_SDK_BIN}/clang" PARENT_SCOPE)
+    set(CMAKE_AR "${WASI_SDK_BIN}/llvm-ar" PARENT_SCOPE)
+    set(CMAKE_RANLIB "${WASI_SDK_BIN}/llvm-ranlib" PARENT_SCOPE)
+    set(CMAKE_LINKER "${WASI_SDK_BIN}/wasm-ld" PARENT_SCOPE)
+    set(CMAKE_C_COMPILER_TARGET ${triple} PARENT_SCOPE)
+    set(CMAKE_CXX_COMPILER_TARGET ${triple} PARENT_SCOPE)
+    set(CMAKE_ASM_COMPILER_TARGET ${triple} PARENT_SCOPE)
+    
+    # Don't look in the sysroot for executables to run during the build
+    set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER PARENT_SCOPE)
+    # Only look in the sysroot (not in the host paths) for the rest
+    set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY PARENT_SCOPE)
+    set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY PARENT_SCOPE)
+    set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY PARENT_SCOPE)
+    
+    # Use compiler-rt builtins (provided by wasi-sdk)
+    set(CLANG_DEFAULT_RTLIB "compiler-rt" PARENT_SCOPE)
+    set(LIBCXX_USE_COMPILER_RT "YES" PARENT_SCOPE)
+    set(LIBCXXABI_USE_COMPILER_RT "YES" PARENT_SCOPE)
+    
+    # Global compiler flags - all targets should use compiler-rt builtins from wasi-sdk
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I'${CMAKE_CURRENT_LIST_DIR}/include' -I'${CMAKE_CURRENT_LIST_DIR}/libc-stubs'" PARENT_SCOPE)
+    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -I'${CMAKE_CURRENT_LIST_DIR}/include' -I'${CMAKE_CURRENT_LIST_DIR}/libc-stubs'" PARENT_SCOPE)
+    
+    # Release-specific compiler and linker flags because CMake does not automatically include them
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3" PARENT_SCOPE)
+    add_link_options($<$<CONFIG:Release>:-Wl,--strip-debug,--lto-O2,--lto-CGO3,-O3>)
+    
+    # Project compiler flags
+    add_compile_options(
+      -stdlib=libc++
+      -fignore-exceptions
+      -D_WASI_EMULATED_SIGNAL
+      -D_WASI_EMULATED_PROCESS_CLOCKS
+      -D_WASI_EMULATED_MMAN
+      -D_WASI_EMULATED_GETPID
+    )
+    
+    # Project linker flags
+    add_link_options(
+      -lwasi-emulated-signal
+      -lwasi-emulated-mman
+      -lwasi-emulated-process-clocks
+      -lwasi-emulated-getpid
+    )
+    
+    # Interface library to enable stubbing exceptions so that they abort upon throw
+    add_library(wasi_sdk_stub_exceptions INTERFACE)
+    target_compile_options(wasi_sdk_stub_exceptions INTERFACE -include "${CMAKE_CURRENT_LIST_DIR}/include/wasi_abort_exceptions")
+    
+    # Interface library to enable reactor model WebAssembly files
+    add_library(wasi_sdk_reactor_module INTERFACE)
+    target_link_options(wasi_sdk_reactor_module INTERFACE -nostartfiles -Wl,--no-entry)
+    
+    add_library(wasi_sdk_stub_libc_unimplmented INTERFACE)
+    target_compile_options(wasi_sdk_stub_libc_unimplmented INTERFACE -include "${CMAKE_CURRENT_LIST_DIR}/include/wasi_stub_libc_unimplmented")
 
-include(${CMAKE_CURRENT_LIST_DIR}/wasi-sdk.bootstrap.cmake)
-wasi_sdk_bootstrap(
-  TAG wasi-sdk-23
-  WASI_SYSROOT_OUTPUT CMAKE_SYSROOT
-  WASI_SDK_BIN_OUTPUT WASI_SDK_BIN
-)
+endfunction()
 
-set(CMAKE_SYSTEM_NAME WASI)
-set(CMAKE_SYSTEM_VERSION 1)
-set(CMAKE_SYSTEM_PROCESSOR wasm32)
-set(triple wasm32-wasip1-threads)
-
-set(CMAKE_C_COMPILER "${WASI_SDK_BIN}/clang")
-set(CMAKE_CXX_COMPILER "${WASI_SDK_BIN}/clang++")
-set(CMAKE_ASM_COMPILER "${WASI_SDK_BIN}/clang")
-set(CMAKE_AR "${WASI_SDK_BIN}/llvm-ar")
-set(CMAKE_RANLIB "${WASI_SDK_BIN}/llvm-ranlib")
-set(CMAKE_LINKER "${WASI_SDK_BIN}/wasm-ld")
-set(CMAKE_C_COMPILER_TARGET ${triple})
-set(CMAKE_CXX_COMPILER_TARGET ${triple})
-set(CMAKE_ASM_COMPILER_TARGET ${triple})
-
-# Don't look in the sysroot for executables to run during the build
-set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
-# Only look in the sysroot (not in the host paths) for the rest
-set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
-set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
-set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
-
-# Use compiler-rt builtins (provided by wasi-sdk)
-set(CLANG_DEFAULT_RTLIB "compiler-rt")
-set(LIBCXX_USE_COMPILER_RT "YES")
-set(LIBCXXABI_USE_COMPILER_RT "YES")
-
-# Global compiler flags - all targets should use compiler-rt builtins from wasi-sdk
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I'${CMAKE_CURRENT_LIST_DIR}/include' -I'${CMAKE_CURRENT_LIST_DIR}/libc-stubs'")
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -I'${CMAKE_CURRENT_LIST_DIR}/include' -I'${CMAKE_CURRENT_LIST_DIR}/libc-stubs'")
-
-# Release-specific compiler and linker flags because CMake does not automatically include them
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
-add_link_options($<$<CONFIG:Release>:-Wl,--strip-debug,--lto-O2,--lto-CGO3,-O3>)
-
-# Project compiler flags
-add_compile_options(
-  -stdlib=libc++
-  -fignore-exceptions
-  -D_WASI_EMULATED_SIGNAL
-  -D_WASI_EMULATED_PROCESS_CLOCKS
-  -D_WASI_EMULATED_MMAN
-  -D_WASI_EMULATED_GETPID
-)
-
-# Project linker flags
-add_link_options(
-  -lwasi-emulated-signal
-  -lwasi-emulated-mman
-  -lwasi-emulated-process-clocks
-  -lwasi-emulated-getpid
-)
-
-# Interface library to enable stubbing exceptions so that they abort upon throw
-add_library(wasi_sdk_stub_exceptions INTERFACE)
-target_compile_options(wasi_sdk_stub_exceptions INTERFACE -include "${CMAKE_CURRENT_LIST_DIR}/include/wasi_abort_exceptions")
-
-# Interface library to enable reactor model WebAssembly files
-add_library(wasi_sdk_reactor_module INTERFACE)
-target_link_options(wasi_sdk_reactor_module INTERFACE -nostartfiles -Wl,--no-entry)
-
-add_library(wasi_sdk_stub_libc_unimplmented INTERFACE)
-target_compile_options(wasi_sdk_stub_libc_unimplmented INTERFACE -include "${CMAKE_CURRENT_LIST_DIR}/include/wasi_stub_libc_unimplmented")

--- a/wit-bindgen.bootstrap.cmake
+++ b/wit-bindgen.bootstrap.cmake
@@ -130,7 +130,7 @@ function(wit_bindgen)
         OUTPUT_VARIABLE wit_codegen_output
     )
     if (NOT wit_codegen_result EQUAL 0)
-        message(FATAL_ERROR "WebAssembly Component Interface (WIT) bindings failed to generate. \n${wit_codegen_output}")
+        message(FATAL_ERROR "WebAssembly Component Interface (WIT) bindings failed to generate. \n${wit_codegen_output} \n${wit_codegen_result}")
     endif()
 
     # Scrape generated files from wit-bindgen


### PR DESCRIPTION
Makes the wasi toolchain bootstrap configurable. This allows users to choose which version of each subdependent tool to install and use for their project.

- **chore: make toolchain initialization generic for all versions of dependent tools**
- **fix: move include guard into init function**
- **fix: prevent toolchain from being initialized multiple times**
- **chore: update readme with updated usage instructions**
- **fix: set wasi tools binary in parent scope**
