### PR TITLE
chore: bootstrap should not overwrite existing files

### DIFF
--- a/wasi-sdk.bootstrap.cmake
+++ b/wasi-sdk.bootstrap.cmake
@@ -84,11 +84,13 @@ function(wasi_sdk_bootstrap)
   endif()
 
   # Extract wasi-sdk toolchain to cache directory
-  message(STATUS "Extracting wasi-sdk toolchain to ${wasi_sdk_root}")
-  execute_process(
-    COMMAND ${CMAKE_COMMAND} -E tar xzf ${wasi_sdk_tarball_path}
-    WORKING_DIRECTORY ${wasi_sdk_root}
-  )
+  if (NOT EXISTS "${wasi_sdk_root}/wasi-sdk-${wasi_sdk_version}-${host_identifier}")
+    message(STATUS "Extracting wasi-sdk toolchain to ${wasi_sdk_root}")
+    execute_process(
+      COMMAND ${CMAKE_COMMAND} -E tar xzf ${wasi_sdk_tarball_path}
+      WORKING_DIRECTORY ${wasi_sdk_root}
+    )
+  endif()
 
   set(${arg_WASI_SYSROOT_OUTPUT}
       "${wasi_sdk_root}/wasi-sdk-${wasi_sdk_version}-${host_identifier}/share/wasi-sysroot"

--- a/wasm-tools.bootstrap.cmake
+++ b/wasm-tools.bootstrap.cmake
@@ -144,11 +144,13 @@ function(wasm_tools_bootstrap)
     endif()
 
     # Extract wasm-tools sysroot to cache directory
-    message(STATUS "Extracting wasm-tools binary to ${wasm_tools_root}")
-    execute_process(
-        COMMAND ${CMAKE_COMMAND} -E tar xzf ${wasm_tools_tarball_path}
-        WORKING_DIRECTORY ${wasm_tools_root}
-    )
+    if (NOT EXISTS "${wasm_tools_root}/wasm-tools-${wasm_tools_version}-${host_identifier}")
+        message(STATUS "Extracting wasm-tools binary to ${wasm_tools_root}")
+        execute_process(
+            COMMAND ${CMAKE_COMMAND} -E tar xzf ${wasm_tools_tarball_path}
+            WORKING_DIRECTORY ${wasm_tools_root}
+        )
+    endif()
 
     # Set location of wasm-tools
     set(${arg_WASM_TOOLS_BINARY_OUTPUT}

--- a/wit-bindgen.bootstrap.cmake
+++ b/wit-bindgen.bootstrap.cmake
@@ -80,11 +80,13 @@ function(wit_bindgen_bootstrap)
     endif()
 
     # Extract wit-bindgen sysroot to cache directory
-    message(STATUS "Extracting wit-bindgen binary to ${wit_bindgen_root}")
-    execute_process(
-        COMMAND ${CMAKE_COMMAND} -E tar xzf ${wit_bindgen_tarball_path}
-        WORKING_DIRECTORY ${wit_bindgen_root}
-    )
+    if (NOT EXISTS "${wit_bindgen_root}/wit-bindgen-${wit_bindgen_version}-${host_identifier}")
+        message(STATUS "Extracting wit-bindgen binary to ${wit_bindgen_root}")
+        execute_process(
+            COMMAND ${CMAKE_COMMAND} -E tar xzf ${wit_bindgen_tarball_path}
+            WORKING_DIRECTORY ${wit_bindgen_root}
+        )
+    endif()
 
     # Set location of wit-bindgen
     set(${arg_WIT_BINDGEN_BINARY_OUTPUT}


### PR DESCRIPTION
The toolchain should not replace an already downloaded and extracted version of `wasi-sdk`, `wasm-tools` or `wit-bindgen`. Instead, it should use the already cached version and leave the existing files untouched.