### PR TITLE
chore: separate flags for sjlj and exceptions

### DIFF
--- a/tests/exceptions_test/toolchain.cmake
+++ b/tests/exceptions_test/toolchain.cmake
@@ -8,4 +8,6 @@ initialize_wasi_toolchain(
   WASM_TOOLS_TAG "v1.245.1"
   WASI_SDK_TAG "wasi-sdk-30.0-cpp-exn"
   TARGET_TRIPLET "wasm32-wasi"
+  ENABLE_EXPERIMENTAL_STUBS ON
+  ENABLE_EXPERIMENTAL_SETJMP ON
 )

--- a/wasi-sdk.toolchain.cmake
+++ b/wasi-sdk.toolchain.cmake
@@ -115,18 +115,17 @@ function(initialize_wasi_toolchain)
     # Optionally add experimental stubs for libc functions
     if (arg_ENABLE_EXPERIMENTAL_STUBS)
       # Add libc-stubs include directories
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I'${CMAKE_CURRENT_FUNCTION_LIST_DIR}/include' -I'${CMAKE_CURRENT_FUNCTION_LIST_DIR}/libc-stubs/include'" PARENT_SCOPE)
-      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -I'${CMAKE_CURRENT_FUNCTION_LIST_DIR}/include' -I'${CMAKE_CURRENT_FUNCTION_LIST_DIR}/libc-stubs/include'" PARENT_SCOPE)
+      include_directories(SYSTEM "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/include" "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/libc-stubs/include")
       # Include libc-stubs static library for linking
       set(LIBC_STUBS_LIB_PATH "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/libc-stubs/install/lib/libc-stubs.a" CACHE FILEPATH "Path to libc stubs")
       set(LIBCXX_STUBS_LIB_PATH "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/libc-stubs/install/lib/libcxx-stubs.a" CACHE FILEPATH "Path to libcxx stubs")
-      add_link_options(${LIBCXX_STUBS_LIB_PATH} ${LIBC_STUBS_LIB_PATH})
+      set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${LIBCXX_STUBS_LIB_PATH} ${LIBC_STUBS_LIB_PATH}" PARENT_SCOPE)
     endif()
 
     if (arg_ENABLE_EXPERIMENTAL_SETJMP)
       # Enable SJLJ support
-      add_compile_options(-mllvm -wasm-enable-sjlj -fwasm-exceptions)
-      add_link_options(-mllvm -wasm-enable-sjlj -lsetjmp -Wl,-mllvm,-wasm-enable-sjlj,-mllvm,-wasm-use-legacy-eh=false)
+      add_compile_options(-mllvm -wasm-enable-sjlj)
+      set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lsetjmp -Wl,-mllvm,-wasm-enable-sjlj,-mllvm,-wasm-use-legacy-eh=false" PARENT_SCOPE)
     else()
       add_compile_options(-fignore-exceptions)
     endif()


### PR DESCRIPTION
* Switched from setting `CMAKE_C_FLAGS` and `CMAKE_CXX_FLAGS` directly to using `include_directories(SYSTEM ...)` for adding experimental libc stub include paths, making the integration cleaner and more maintainable.

* Changed the way static libraries for libc stubs are linked by appending them to `CMAKE_EXE_LINKER_FLAGS` instead of using `add_link_options`, ensuring better compatibility with toolchain usage.

* Updated setjmp experimental feature to append linker flags to `CMAKE_EXE_LINKER_FLAGS` instead of `add_link_options`, and removed `-fwasm-exceptions` from compile options for better control over exception handling.