### PR TITLE
fix: suppress warnings about unused llvm flags

### DIFF
--- a/wasi-sdk.toolchain.cmake
+++ b/wasi-sdk.toolchain.cmake
@@ -66,7 +66,14 @@ function(initialize_wasi_toolchain)
         WASI_SYSROOT_OUTPUT CMAKE_SYSROOT
         WASI_SDK_BIN_OUTPUT WASI_SDK_BIN
       )
-      string(APPEND CMAKE_CXX_FLAGS " -fwasm-exceptions -mllvm -wasm-use-legacy-eh=false -Wl,-lunwind")
+
+      # Wrap -mllvm flags to suppress unused-argument warnings during link steps.
+      string(APPEND CMAKE_CXX_FLAGS " --start-no-unused-arguments")
+      string(APPEND CMAKE_CXX_FLAGS " -mllvm -wasm-use-legacy-eh=false -Wl,-lunwind")
+      string(APPEND CMAKE_CXX_FLAGS " --end-no-unused-arguments")
+
+      # Link against libunwind for exception handling support.
+      string(APPEND CMAKE_CXX_FLAGS " -fwasm-exceptions")
       string(APPEND CMAKE_EXE_LINKER_FLAGS " -lunwind")
     else()
       include(${CMAKE_CURRENT_FUNCTION_LIST_DIR}/wasi-sdk.bootstrap.cmake)
@@ -123,9 +130,15 @@ function(initialize_wasi_toolchain)
     endif()
 
     if (arg_ENABLE_EXPERIMENTAL_SETJMP)
-      # Enable SJLJ support
+      # Wrap -mllvm flags to suppress unused-argument warnings during link steps.
+      string(APPEND CMAKE_C_FLAGS " --start-no-unused-arguments")
       string(APPEND CMAKE_C_FLAGS " -mllvm -wasm-enable-sjlj -mllvm -wasm-use-legacy-eh=false -Wl,-lsetjmp")
+      string(APPEND CMAKE_C_FLAGS " --end-no-unused-arguments")
+      string(APPEND CMAKE_CXX_FLAGS " --start-no-unused-arguments")
       string(APPEND CMAKE_CXX_FLAGS " -mllvm -wasm-enable-sjlj -mllvm -wasm-use-legacy-eh=false -Wl,-lsetjmp")
+      string(APPEND CMAKE_CXX_FLAGS " --end-no-unused-arguments")
+
+      # Link against setjmp library for setjmp/longjmp support.
       string(APPEND CMAKE_EXE_LINKER_FLAGS " -lsetjmp")
     endif()
 


### PR DESCRIPTION
This pull request updates the `initialize_wasi_toolchain` function in `wasi-sdk.toolchain.cmake` to improve compatibility with older versions of clang and clarify linker flag usage. Ensures that certain `-mllvm` flags do not trigger unused argument warnings, and library linking for exception and setjmp/longjmp support is made more explicit.

* Wrapped `-mllvm` flags with `--start-no-unused-arguments` and `--end-no-unused-arguments` in both `CMAKE_C_FLAGS` and `CMAKE_CXX_FLAGS` to avoid unused argument warnings in older clang versions. [[1]](diffhunk://#diff-6dc8e412041106ce6483ae4d68932064d30b87d176b76cf9c5c2a030caffc089L69-R79) [[2]](diffhunk://#diff-6dc8e412041106ce6483ae4d68932064d30b87d176b76cf9c5c2a030caffc089L126-R144)
* Moved `-fwasm-exceptions` to only be appended to `CMAKE_CXX_FLAGS` and clarified linking against `libunwind` for exception handling by using `-lunwind` in `CMAKE_EXE_LINKER_FLAGS`.
* Clarified linking against the `setjmp` library for setjmp/longjmp support by using `-lsetjmp` in `CMAKE_EXE_LINKER_FLAGS`.