### PR TITLE
chore: also run tests in nodejs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,8 @@ jobs:
 
       - name: Run test (${{ matrix.test }})
         working-directory: ./tests/${{ matrix.test }}
+        env:
+          NODE_OPTIONS: ${{ matrix.node-version == 24 && '--experimental-wasm-exnref' || '' }}
         run: |
             cmake -B ./build -DCMAKE_TOOLCHAIN_FILE=./toolchain.cmake
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,10 +28,16 @@ jobs:
       fail-fast: false
       matrix:
         test: ${{ fromJson(needs.discover-tests.outputs.tests) }}
+        node-version: [22, 24]
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
 
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v2

--- a/tests/add_tryrun_test.cmake
+++ b/tests/add_tryrun_test.cmake
@@ -5,6 +5,15 @@ function(add_tryrun_test test_name test_file)
     set(COMPILE_RESULT_VAR "")
     set(COMPILE_OUTPUT_VAR "")
 
+    set(TEST_RUN_MESSAGE "Running test '${test_name}'...")
+    string(LENGTH "${TEST_RUN_MESSAGE}" LEN)
+    string(REPEAT "=" ${LEN} SEPARATOR)
+
+    message(STATUS "")
+    message(STATUS "${SEPARATOR}")
+    message(STATUS "${TEST_RUN_MESSAGE}")
+    message(STATUS "${SEPARATOR}")
+
     # Try compiling and running a source file (e.g., test.c)
     try_run(
         RUN_RESULT_VAR
@@ -14,15 +23,6 @@ function(add_tryrun_test test_name test_file)
         RUN_OUTPUT_VARIABLE RUN_OUTPUT_VAR
         COMPILE_OUTPUT_VARIABLE COMPILE_OUTPUT_VAR
     )
-
-    set(TEST_RUN_MESSAGE "Running test '${test_name}'...")
-    string(LENGTH "${TEST_RUN_MESSAGE}" LEN)
-    string(REPEAT "=" ${LEN} SEPARATOR)
-
-    message(STATUS "")
-    message(STATUS "${SEPARATOR}")
-    message(STATUS "${TEST_RUN_MESSAGE}")
-    message(STATUS "${SEPARATOR}")
 
     # Use the results
     if("${COMPILE_RESULT_VAR}" STREQUAL "TRUE")
@@ -40,3 +40,51 @@ function(add_tryrun_test test_name test_file)
         message(SEND_ERROR "Test program '${test_name}' failed to compile: ${COMPILE_OUTPUT_VAR}")
     endif()
 endfunction(add_tryrun_test)
+
+function(add_tryrun_node_test test_name test_file)
+    # Define variables to store the results
+    set(RUN_RESULT_VAR "")
+    set(RUN_OUTPUT_VAR "")
+    set(COMPILE_RESULT_VAR "")
+    set(COMPILE_OUTPUT_VAR "")
+
+    set(TEST_RUN_MESSAGE "Running test in NodeJS '${test_name}'...")
+    string(LENGTH "${TEST_RUN_MESSAGE}" LEN)
+    string(REPEAT "=" ${LEN} SEPARATOR)
+
+    message(STATUS "")
+    message(STATUS "${SEPARATOR}")
+    message(STATUS "${TEST_RUN_MESSAGE}")
+    message(STATUS "${SEPARATOR}")
+
+    # Try compiling and running a source file (e.g., test.c)
+    try_compile(
+        COMPILE_RESULT_VAR
+        ${CMAKE_CURRENT_BINARY_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/${test_file}
+        OUTPUT_VARIABLE COMPILE_OUTPUT_VAR
+        COPY_FILE ${CMAKE_CURRENT_BINARY_DIR}/main.wasm
+    )
+
+    # Run the test program also with Node.js to verify it works in a real environment.
+    if("${COMPILE_RESULT_VAR}" STREQUAL "TRUE")
+        execute_process(
+            COMMAND node ${CMAKE_CURRENT_SOURCE_DIR}/../runner.mjs ${CMAKE_CURRENT_BINARY_DIR}/main.wasm
+            RESULT_VARIABLE NODE_RUN_RESULT
+            OUTPUT_VARIABLE NODE_RUN_OUTPUT
+            ERROR_VARIABLE NODE_RUN_ERROR
+        )
+        if(NODE_RUN_RESULT EQUAL 0)
+            message(STATUS "Node.js output:")
+            message(STATUS "${NODE_RUN_OUTPUT}")
+        else()
+            message(SEND_ERROR "Node.js execution failed with exit code: ${NODE_RUN_RESULT}")
+            message(SEND_ERROR "${NODE_RUN_ERROR}")
+        endif()
+    else()
+        message(SEND_ERROR "Test program '${test_name}' failed to compile: ${COMPILE_OUTPUT_VAR}")
+        message(SEND_ERROR "Compiler output:")
+        message(SEND_ERROR "${COMPILE_OUTPUT_VAR}")
+    endif()
+
+endfunction(add_tryrun_node_test)

--- a/tests/exceptions_test/CMakeLists.txt
+++ b/tests/exceptions_test/CMakeLists.txt
@@ -12,3 +12,4 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_tryrun_test(${TEST_NAME} main.cpp)
+add_tryrun_node_test(${TEST_NAME} main.cpp)

--- a/tests/runner.mjs
+++ b/tests/runner.mjs
@@ -1,0 +1,37 @@
+#! /usr/bin/env node
+
+import { readFile } from 'fs/promises';
+import { WASI } from 'wasi';
+
+
+async function main() {
+    const inputFile = process.argv[2];
+    if (!inputFile) {
+        console.error(`Usage: ${process.argv[1]} <input_file>`);
+        process.exit(1);
+    }
+
+    const wasmBytes = await readFile(inputFile);
+    const wasi = new WASI({
+        version: 'preview1',
+        args: process.argv,
+        env: process.env,
+        stdin: 0,
+        stdout: 1,
+        stderr: 2,
+        preopens: {},
+    });
+
+    const wasmModule = await WebAssembly.compile(wasmBytes);
+    const instance = await WebAssembly.instantiate(wasmModule, {
+        wasi_snapshot_preview1: wasi.wasiImport,
+    });
+
+    const status = wasi.start(instance);
+    process.exit(status);
+}
+
+main().catch(err => {
+    console.error(`Error: ${err}`);
+    process.exit(1);
+});

--- a/tests/sjlj_test/CMakeLists.txt
+++ b/tests/sjlj_test/CMakeLists.txt
@@ -12,3 +12,4 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_tryrun_test(${TEST_NAME} main.cpp)
+add_tryrun_node_test(${TEST_NAME} main.cpp)

--- a/tests/smoke_test/CMakeLists.txt
+++ b/tests/smoke_test/CMakeLists.txt
@@ -11,3 +11,4 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_tryrun_test(${TEST_NAME} main.cpp)
+add_tryrun_node_test(${TEST_NAME} main.cpp)


### PR DESCRIPTION
This pull request adds support for running tests in a Node.js environment in addition to the existing native test execution, improving coverage. 

* Added a new CMake function `add_tryrun_node_test` in `add_tryrun_test.cmake` to compile test programs to WebAssembly and run them using Node.js with WASI, reporting results and errors appropriately.
* Updated test CMake configuration files (`CMakeLists.txt` in `exceptions_test`, `sjlj_test`, and `smoke_test`) to use the new `add_tryrun_node_test` function, ensuring all relevant tests are executed in both native and Node.js environments. [[1]](diffhunk://#diff-66c4cdf981a525e41785068071f274d83a92993fd8429f1b10af1aa9891821e3R15) [[2]](diffhunk://#diff-a34cefd9a91ea1274dc2cc9514a8896ade5af603bb3c9b25d6198a64ece711a4R15) [[3]](diffhunk://#diff-49a80bea259150891382c628895b3ac8259d9f9255e801b9dbdcbedb62dbb4e2R14)
* Modified the GitHub Actions workflow (`.github/workflows/test.yml`) to set up and run tests with both Node.js 22 and 24, ensuring compatibility across multiple Node.js versions.
* Added a new `runner.mjs` script to execute WebAssembly test binaries in Node.js using the WASI API, handling argument passing, environment variables, and error reporting.
* Cleaned up redundant code in the original `add_tryrun_test` function for improved readability. [[1]](diffhunk://#diff-c65adadce0f5f9c2cc7f8a7e151fbb15c485d336c5a6ebedfb6165237ae7f644R8-R16) [[2]](diffhunk://#diff-c65adadce0f5f9c2cc7f8a7e151fbb15c485d336c5a6ebedfb6165237ae7f644L18-L26)